### PR TITLE
feat: Implemented Tagged Strings support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,3 +317,4 @@ pub use crate::value::Value;
 
 #[cfg(feature = "tags")]
 pub use tag::EncodeCborTag;
+pub use tag::TaggedString;

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,4 +1,5 @@
 use serde::ser::{Serialize, SerializeStruct, Serializer};
+use serde::de::{Deserialize, Deserializer};
 
 /// Wrapper struct to handle encoding Cbor semantic tags.
 #[derive(Deserialize)]
@@ -36,5 +37,40 @@ impl<T: Serialize> Serialize for EncodeCborTag<T> {
         state.serialize_field("__cbor_tag_ser_tag", &self.__cbor_tag_ser_tag)?;
         state.serialize_field("__cbor_tag_ser_data", &self.__cbor_tag_ser_data)?;
         state.end()
+    }
+}
+
+/// TaggedString
+#[derive(Clone, Debug, PartialEq)]
+pub struct TaggedString {
+    /// Tag
+    pub tag: u64,
+    /// Raw String to be tagged
+    pub data: String,
+}
+
+impl TaggedString {
+    /// Returns tag
+    pub fn tag(&self) -> u64 {
+        return self.tag;
+    }
+}
+
+impl Serialize for TaggedString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        EncodeCborTag::new(self.tag, &self.data).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for TaggedString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wrapper = EncodeCborTag::deserialize(deserializer)?;
+        Ok(TaggedString {tag: wrapper.tag(), data: wrapper.value() })
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -5,6 +5,7 @@ mod ser;
 
 use std::cmp::{Ord, Ordering, PartialOrd};
 use std::collections::BTreeMap;
+use crate::tag::TaggedString;
 
 #[doc(inline)]
 pub use self::de::from_value;
@@ -53,6 +54,8 @@ pub enum Value {
     Map(BTreeMap<Value, Value>),
     /// Semantic Tag
     Tag(u64),
+    /// Tagged String
+    TaggedString(TaggedString),
     // The hidden variant allows the enum to be extended
     // with variants for tags and simple values.
     #[doc(hidden)]
@@ -150,6 +153,7 @@ impl Value {
             Array(_) => 4,
             Map(_) => 5,
             Tag(_) => 6,
+            TaggedString(_) => 8,
             __Hidden => unreachable!(),
         }
     }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -25,6 +25,14 @@ impl serde::Serialize for Value {
             Value::Text(ref v) => serializer.serialize_str(&v),
             Value::Array(ref v) => v.serialize(serializer),
             Value::Tag(v) => serializer.serialize_u64(v),
+            Value::TaggedString(ref v) => {
+                    use serde::ser::SerializeStruct;
+
+                    let mut s = serializer.serialize_struct("EncodeCborTag", 2)?;
+                    s.serialize_field("__cbor_tag_ser_tag", &Value::Tag(v.tag))?;
+                    s.serialize_field("__cbor_tag_ser_data", &v.data.to_owned())?;
+                    return s.end();
+            },
             Value::Map(ref v) => {
                 if v.len() == 2 {
                     use serde::ser::SerializeStruct;

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -323,4 +323,31 @@ mod std_tests {
             serde_cbor::de::from_slice(&[0xd9, 0xd9, 0xf6, 0x83, 0x01, 0x02, 0x03]).unwrap();
         assert_eq!(value, (55798, (1, 2, 3)));
     }
+
+
+#[cfg(feature = "tags")]
+    #[test]
+    fn test_tagged_string() {
+        /* D8 20             # tag(32)
+           67                # text(7)
+           6578616D706C65 # "example" */
+        use serde_cbor::TaggedString;
+        const CBOR_ENCODED: [u8;10] = [0xd8,0x20,0x67,0x65,0x78,0x61,0x6d,0x70,0x6c,0x65];
+
+        let tagged_string = TaggedString {tag: 32, data: String::from("example")};
+
+        // Serialize tagged string (CBOR encode)
+        let ser_result = serde_cbor::to_vec(&tagged_string).unwrap();
+        assert_eq!(ser_result, CBOR_ENCODED);
+        println!("{:?}", ser_result);
+
+
+       // Deserialize tagged string (CBOR decode)
+        let de_result: (TaggedString) =
+            serde_cbor::de::from_slice_with_scratch(&CBOR_ENCODED, &mut []).unwrap();
+        assert_eq!(32, de_result.tag);
+        assert_eq!(String::from("example"), de_result.data);
+        println!("{:?}", de_result);
+    }
+
 }


### PR DESCRIPTION
A contribution to String tag support in Serdes.
Rust lacks **specialization** support yet, therefore type implementation must be done from within the library.


According to [Concise Binary Object Representation (CBOR)](https://tools.ietf.org/html/rfc7049)
CBOR URI (CBOR type 32) must be represented as a UTF-8 String with tag 32.
The changes done in this pull request allows one to successfully represent it by using the following code:

Example:
```
let cbor_uri_encoded = serde_cbor::TaggedString{tag: 32, data: "example".to_string()};
let encoded = serde_cbor::to_vec(&cbor_uri_encoded);

```
[CBOR playground](http://cbor.me)
32("example")

D8 20                # tag(32)
   67                # text(7)
      6578616D706C65 # "example"